### PR TITLE
Fix phpCas::setDebug() deprecated

### DIFF
--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -77,7 +77,7 @@ class CasAuthenticator extends AbstractGuardAuthenticator implements LogoutSucce
      */
     public function getCredentials(Request $request)
     {
-        phpCAS::setDebug($this->cas->getDebug());
+        phpCAS::setLogger($this->cas->getDebug());
         phpCAS::setVerbose($this->cas->isVerbose());
         if (!phpCAS::isInitialized()) {
             phpCAS::client(
@@ -247,7 +247,7 @@ class CasAuthenticator extends AbstractGuardAuthenticator implements LogoutSucce
      */
     public function onLogoutSuccess(Request $request)
     {
-        phpCAS::setDebug($this->cas->getDebug());
+        phpCAS::setLogger($this->cas->getDebug());
         phpCAS::setVerbose($this->cas->isVerbose());
         if (!phpCAS::isInitialized()) {
             phpCAS::client(

--- a/Tests/Security/CasAuthenticatorTest.php
+++ b/Tests/Security/CasAuthenticatorTest.php
@@ -98,7 +98,7 @@ class CasAuthenticatorTest extends TestCase
             echo 'YES I CALL THE MOCKED Debug function';
         }]);
 
-        phpCAS::setDebug();
+        phpCAS::setLogger();
         $phpCas->verifyInvoked('setDebug', false);
         self::expectOutputString('YES I CALL THE MOCKED Debug function');
     }


### PR DESCRIPTION
Hey,

I'm trying to upgrade an application to Symfony5, so here's a PR to fix setDebug() which is deprecated.

You have an issue regarding this #13.